### PR TITLE
Reflects transfer of repo to delb-xml

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,8 +11,8 @@ snakesist
     :target: https://snakesist.readthedocs.io/en/latest/?badge=latest
     :alt: Documentation Status
 
-.. image:: https://travis-ci.org/03b8/snakesist.svg?branch=master
-    :target: https://travis-ci.org/03b8/snakesist
+.. image:: https://github.com/delb-xml/snakesist/actions/workflows/tests.yml/badge.svg
+    :target: https://github.com/delb-xml/snakesist/actions/workflows/tests.yml
 
 
 ``snakesist`` is a Python database interface for `eXist-db <https://exist-db.org>`_.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "A Python database interface for eXist-db"
 license = "MIT"
 authors = ["Theodor Costea <theo.costea@gmail.com>", "Frank Sachsenheim <funkyfuture@riseup.net>"]
 readme = "README.rst"
-repository = "https://github.com/03b8/snakesist"
+repository = "https://github.com/delb-xml/snakesist"
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",


### PR DESCRIPTION
these changes reflect the anticipation that you will move this repo under the umbrella of https://github.com/delb-xml

you're invited to join the org. let me know any obstacles.

we could add the solution to #40 here as well.