### PR TITLE
Switch database query requests from `GET` to `POST`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -63,8 +63,8 @@ Your eXist instance
 
 ``snakesist`` leverages the
 `eXist RESTful API <https://www.exist-db.org/exist/apps/doc/devguide_rest.xml>`_
-for database queries. This means that allowing database queries using the
-``_query`` parameter of the RESTful API is a requirement in the used eXist-db
+for database queries. This means that allowing database queries using
+POST requests on the RESTful API is a requirement in the used eXist-db
 backend. eXist allows this by default, so if you haven't configured your
 instance otherwise, don't worry about it.
 

--- a/snakesist/exist_client.py
+++ b/snakesist/exist_client.py
@@ -45,6 +45,20 @@ DEFAULT_PARSER = etree.XMLParser(recover=True)
 EXISTDB_NAMESPACE = "http://exist.sourceforge.net/NS/exist"
 TRANSPORT_PROTOCOLS = {"https": 443, "http": 80}  # the order matters!
 XML_NAMESPACE = "https://snakesist.readthedocs.io/"
+XQUERY_PAYLOAD_TEMPLATE = (
+    '<query '
+    f'xmlns="{EXISTDB_NAMESPACE}" '
+    'start="1" '
+    'max="0" '
+    'cache="no">'
+    '<text> <![CDATA[{query}]]></text>'
+    '<properties>'
+    '<property name="indent" value="no"/>'
+    '<property name="wrap" value="yes"/>'
+    '</properties>'
+    '</query>'
+)
+
 
 
 fetch_resource_paths = cssselect.CSSSelector(
@@ -382,17 +396,10 @@ class ExistClient:
         :return: The query result as a ``delb.Document`` object.
         """
 
-        params = {
-            "_howmany": "0",
-            "_indent": "no",
-            "_wrap": "yes",
-            "_query": query_expression,
-        }
-
-        response = requests.get(
+        response = requests.post(
             self.root_collection_url,
             headers={"Content-Type": "application/xml"},
-            params=params,
+            data=XQUERY_PAYLOAD_TEMPLATE.format(query=query_expression).encode(),
         )
 
         try:

--- a/tests/test_exist_client.py
+++ b/tests/test_exist_client.py
@@ -1,3 +1,5 @@
+import uuid
+
 import pytest  # type: ignore
 import requests
 
@@ -75,3 +77,14 @@ def test_url_parsing(url, properties):
     assert client.host == properties[3]
     assert client.port == properties[4]
     assert client.prefix == properties[5]
+
+
+@pytest.mark.parametrize("text_length", [7000, 8000, 9000, 10000])
+def test_query_with_lengthy_contents(test_client, text_length):
+    long_paragraph = "a" * text_length
+    Document(
+        f'<example id="t8"><p>{long_paragraph}</p></example>', existdb_client=test_client
+    ).existdb_store(filename=f"{uuid.uuid4()}.xml")
+
+    retrieved_nodes = test_client.xpath(f'//p[contains(., "{long_paragraph}")]')
+    assert len(retrieved_nodes) == 1

--- a/tests/test_exist_client.py
+++ b/tests/test_exist_client.py
@@ -1,5 +1,3 @@
-import uuid
-
 import pytest  # type: ignore
 import requests
 

--- a/tests/test_exist_client.py
+++ b/tests/test_exist_client.py
@@ -79,12 +79,12 @@ def test_url_parsing(url, properties):
     assert client.prefix == properties[5]
 
 
-@pytest.mark.parametrize("text_length", [7000, 8000, 9000, 10000])
-def test_query_with_lengthy_contents(test_client, text_length):
-    long_paragraph = "a" * text_length
+def test_query_with_lengthy_contents(test_client):
+    document = Document("existdb://localhost/exist/db/apps/test-data/dada_manifest.xml")
+    long_paragraph = document.root.full_text * 5  # 30625 characters total length
     Document(
         f'<example id="t8"><p>{long_paragraph}</p></example>', existdb_client=test_client
-    ).existdb_store(filename=f"{uuid.uuid4()}.xml")
+    ).existdb_store(filename="the_long_dada.xml")
 
     retrieved_nodes = test_client.xpath(f'//p[contains(., "{long_paragraph}")]')
     assert len(retrieved_nodes) == 1


### PR DESCRIPTION
Fixes #45 by passing XQuery expressions in the body of a `POST` request instead of in a query parameter of a `GET` request. I parametrized the test for this with some values on both sides of the failure threshold (which appears to be roughly around 8000 characters).