### PR TITLE
tests: Adds further exist versions as targets

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,11 @@ jobs:
           - "3.12"
         exist-version:
           - "4.10.0"
+          - "4.11.1"
           - "5.4.1"
+          - "5.5.1"
+          - "6.0.1"
+          - "6.1.0"
           - "6.2.0"
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
I added all patch releases that surfaced since the exist-dimension was added to the target matrix. Also the 6.0.1 that dependabot removed.

This is debatable since it isn't necessary to comply with the formulated support promise. I opened an issue at the exist's people place with the request on a clear documentation which versions they support.

Neither do I know how the tests will result. Let Microsoft pay the bills!